### PR TITLE
exvars parameter not working on round-robin

### DIFF
--- a/main.go
+++ b/main.go
@@ -360,15 +360,15 @@ func localMain(loop, maxScenario, maxRequest, totalDuration int, config *Config,
 	}
 
 	// attack
-	offset := map[string]int{}
 	for i := 0; i < loop*maxScenario; i++ {
 		wg.Add(1)
+		offset := map[string]int{}
 		for k := range EXVARS {
+			offset[k] = EXVARS[k].Offset
 			EXVARS[k].Offset += 1
 			if EXVARS[k].Offset >= len(EXVARS[k].Value) {
 				EXVARS[k].Offset = 0
 			}
-			offset[k] = EXVARS[k].Offset
 		}
 		w := Worker{Client: client, Config: config, ExVarOffset: offset}
 		limiter <- w


### PR DESCRIPTION
Probably EXVARS offset initialization is missing before worker setting.

```
% cat example.yml
domain: http://example.com/
actions:
    - path: /
exvars:
    - name: _
      file: query.txt
query_params:
    _: "%(_)%"
```

```
% cat query.txt
0
1
2
3
4
5
6
7
8
9
```

```
% gohakai -n 6 -c 1 -verbose example.yml
2016/01/23 14:42:42 GET /?_=2
2016/01/23 14:42:42 264.747322ms 200 -1
2016/01/23 14:42:42 GET /?_=3
2016/01/23 14:42:43 130.533739ms 200 -1
2016/01/23 14:42:43 GET /?_=4
2016/01/23 14:42:43 130.3825ms 200 -1
2016/01/23 14:42:43 GET /?_=5
2016/01/23 14:42:43 130.348627ms 200 -1
2016/01/23 14:42:43 GET /?_=6
2016/01/23 14:42:43 130.851899ms 200 -1
2016/01/23 14:42:43 GET /?_=6
2016/01/23 14:42:43 134.467815ms 200 -1

request count:6, concurrency:1, time:0.92312[s], 6.499678[req/s]
SUCCESS 6
FAILED 0
Average response time[ms]: 153.555317
```

```
% gohakai -n 6 -c 3 -verbose example.yml
2016/01/23 14:43:08 GET /?_=4
2016/01/23 14:43:08 GET /?_=4
2016/01/23 14:43:08 GET /?_=4
2016/01/23 14:43:09 256.174155ms 200 -1
2016/01/23 14:43:09 GET /?_=6
2016/01/23 14:43:09 264.199258ms 200 -1
2016/01/23 14:43:09 GET /?_=6
2016/01/23 14:43:09 270.398372ms 200 -1
2016/01/23 14:43:09 GET /?_=6
2016/01/23 14:43:09 125.287722ms 200 -1
2016/01/23 14:43:09 135.216033ms 200 -1
2016/01/23 14:43:09 143.228253ms 200 -1

request count:6, concurrency:3, time:0.41444[s], 14.477213[req/s]
SUCCESS 6
FAILED 0
Average response time[ms]: 199.0839655
```
